### PR TITLE
Scs0009

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,12 @@ project(${project} LANGUAGES CXX)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
 
 # Include SMS_STS, SCSCL, HLSCL, and base classes
-set(hdrs include/SMS_STS.h include/SCSerial.h include/SCS.h include/SCSCL.h
+set(hdrs include/SMS_STS.h include/SCSerial.h include/SCS.h include/SCSCL.h 
+         include/SCS0009.h
          include/INST.h include/HLSCL.h include/ServoUtils.h
          include/SyncWriteBuffer.h include/ServoErrors.h include/SCServo.h)
-set(srs src/SMS_STS.cpp src/SCSerial.cpp src/SCS.cpp src/SCSCL.cpp src/HLSCL.cpp)
+set(srs src/SMS_STS.cpp src/SCSerial.cpp src/SCS.cpp src/SCSCL.cpp src/SCS0009.cpp
+        src/HLSCL.cpp)
 
 add_library(${project} STATIC ${hdrs} ${srs})
 target_include_directories(${project} PUBLIC

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # SCServo_Linux
 
 ![Project Status](https://img.shields.io/badge/Status-Active-green)
-[![Repository](https://img.shields.io/badge/Repo-adityakamath%2FSCServo__Linux-purple?style=flat&logo=github&logoSize=auto)](https://github.com/adityakamath/SCServo_Linux)
-[![Blog](https://img.shields.io/badge/Blog-kamathrobotics.com-darkorange?style=flat&logo=hashnode&logoSize=auto)](https://kamathrobotics.com/serial-bus-servo-motors-in-2025)
-[![Ask DeepWiki (Experimental)](https://deepwiki.com/badge.svg)](https://deepwiki.com/adityakamath/SCServo_Linux)
 ![C++](https://img.shields.io/badge/C++-17-blue?style=flat&logo=cplusplus&logoColor=white)
+[![Ask DeepWiki (Experimental)](https://deepwiki.com/badge.svg)](https://deepwiki.com/adityakamath/SCServo_Linux)
+[![Blog](https://img.shields.io/badge/Blog-kamathrobotics.com-darkorange?style=flat&logo=hashnode&logoSize=auto)](https://kamathrobotics.com/serial-bus-servo-motors-in-2025)
 ![License](https://img.shields.io/github/license/adityakamath/SCServo_Linux?label=License)
 
 Linux SDK for Feetech serial servo motors with native C++ support
 
 A high-performance Linux SDK for controlling Feetech SMS/STS/SCSCL/HLSCL series serial bus servo motors. Features position, velocity, PWM, and force control with multi-servo synchronization support.
 
-> **📌 About This Fork:** This repository is a fork of Feetech's official [FTServo_Linux](https://gitee.com/ftservo/FTServo_Linux) SDK with enhanced documentation and code quality improvements. Most enhancements were AI-generated, but under strict human supervision. The original repository on Gitee is fully functional and can be used if you prefer the unmodified SDK. This fork focuses on improved usability, comprehensive documentation, and additional examples for the Linux platform.
+> **📌 About This Fork:** This is a fork of Aditya Kamath's [SCServo_Linux](https://github.com/adityakamath/SCServo_Linux), adding support for the SCS0009 servo used in the [AmazingHand](https://github.com/pollen-robotics/AmazingHand) from [Pollen Robotics](https://https://www.pollen-robotics.com/). Feetech uses different firmware on each of their different servo product families, which means the SCS0009 has enough differences in register addresses, values, etc. 
+> This is important for those who want to add an AmazingHand to their [Reachy](https://www.pollen-robotics.com/) or [SO-10x arm](https://github.com/TheRobotStudio/SO-ARM100)
+>
+> 
 
 ## Table of Contents
 
@@ -27,7 +29,7 @@ A high-performance Linux SDK for controlling Feetech SMS/STS/SCSCL/HLSCL series 
 
 ## Features
 
-- **Protocol Support**: SMS/STS, SCSCL, HLSCL series
+- **Protocol Support**: SMS/STS, SCSCL, HLSCL and SCS0009 series
 - **Control Modes**: Position (servo with velocity/acceleration), Velocity (closed-loop wheel), PWM (open-loop wheel), Force/Torque (constant force output - HLSCL only)
 - **Multi-Servo Operations**: Synchronized Write / Broadcast commands
 - **Comprehensive Feedback**: Position, speed, load, voltage, temperature, current readings
@@ -44,9 +46,10 @@ A high-performance Linux SDK for controlling Feetech SMS/STS/SCSCL/HLSCL series 
 |----------|--------|-------------------|---------------------|------------------|
 | SMS/STS  | STS3215, STS3032, STS3250, SMS40 | 1000000 (STS), 115200 (SMS) | 12-bit (0-4095) | Standard modes |
 | SCSCL    | SC09, SC15 | 115200, 1000000 | 10-bit (0-1023) | Position + PWM |
-| HLSCL    | HLS series | 115200, 1000000 | 12-bit (0-4095) | **Includes force/torque mode** |
+| HLSCL    | HLS series | 115200, 1000000 | 12-bit (0-4095) | **Includes force/torque modehttps://github.com/TheRobotStudio/SO-ARM100https://github.com/TheRobotStudio/SO-ARM100** |
+| SCS0009 | SCS000 series | 115200,1000000 | 10-bit (0-1023) | Standard Modes, Response Timing, Status Messages |
 
-\* Factory default is typically 1000000 (1M) for most models, but can be reconfigured. Check your specific servo's current setting.
+\https://github.com/TheRobotStudio/SO-ARM100* Factory default is typically 1000000 (1M) for most models, but can be reconfigured. Check your specific servo's current setting.
 
 ### Connection Requirements
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Linux SDK for Feetech serial servo motors with native C++ support
 
 A high-performance Linux SDK for controlling Feetech SMS/STS/SCSCL/HLSCL series serial bus servo motors. Features position, velocity, PWM, and force control with multi-servo synchronization support.
 
-> **📌 About This Fork:** This is a fork of Aditya Kamath's [SCServo_Linux](https://github.com/adityakamath/SCServo_Linux), adding support for the SCS0009 servo used in the [AmazingHand](https://github.com/pollen-robotics/AmazingHand) from [Pollen Robotics](https://https://www.pollen-robotics.com/). Feetech uses different firmware on each of their different servo product families, which means the SCS0009 has enough differences in register addresses, values, etc. 
-> This is important for those who want to add an AmazingHand to their [Reachy](https://www.pollen-robotics.com/) or [SO-10x arm](https://github.com/TheRobotStudio/SO-ARM100)
+> **📌 Added support for the SCS0009 servo used in the [AmazingHand](https://github.com/pollen-robotics/AmazingHand) from [Pollen Robotics](https://www.pollen-robotics.com/). Feetech uses different firmware on each of their different servo product families, which means the SCS0009 has enough differences in register addresses, values, etc. to need its own driver. SCS0009 support is useful for those who want to use SCServo_Linux with an [AmazingHand](https://github.com/pollen-robotics/AmazingHand) or integrate it into programming their [Reachy](https://www.pollen-robotics.com/) or [SO-10x arm](https://github.com/TheRobotStudio/SO-ARM100).
 >
 > 
 
@@ -46,10 +45,10 @@ A high-performance Linux SDK for controlling Feetech SMS/STS/SCSCL/HLSCL series 
 |----------|--------|-------------------|---------------------|------------------|
 | SMS/STS  | STS3215, STS3032, STS3250, SMS40 | 1000000 (STS), 115200 (SMS) | 12-bit (0-4095) | Standard modes |
 | SCSCL    | SC09, SC15 | 115200, 1000000 | 10-bit (0-1023) | Position + PWM |
-| HLSCL    | HLS series | 115200, 1000000 | 12-bit (0-4095) | **Includes force/torque modehttps://github.com/TheRobotStudio/SO-ARM100https://github.com/TheRobotStudio/SO-ARM100** |
+| HLSCL    | HLS series | 115200, 1000000 | 12-bit (0-4095) | **Includes force/torque mode** |
 | SCS0009 | SCS000 series | 115200,1000000 | 10-bit (0-1023) | Standard Modes, Response Timing, Status Messages |
 
-\https://github.com/TheRobotStudio/SO-ARM100* Factory default is typically 1000000 (1M) for most models, but can be reconfigured. Check your specific servo's current setting.
+* Factory default is typically 1000000 (1M) for most models, but can be reconfigured. Check your specific servo's current setting.
 
 ### Connection Requirements
 
@@ -65,7 +64,7 @@ A high-performance Linux SDK for controlling Feetech SMS/STS/SCSCL/HLSCL series 
 - Ubuntu 20.04/22.04 (x86_64, ARM64)
 - Raspberry Pi OS (Pi 3/4/5, Zero 2)
 
-> **⚠️ Important:** This SDK has only been tested with **STS3215** servo motors. While it should work with other SMS/SCSCL/HLSCL series motors according to protocol specifications, exercise caution and thoroughly test functionality before deploying with other motor models.
+> **⚠️ Important:** This SDK has only been tested with **STS3215** and **SCS0009** servo motors. While it should work with other SMS/SCSCL/HLSCL series motors according to protocol specifications, exercise caution and thoroughly test functionality before deploying with other motor models.
 
 ## Installation
 

--- a/examples/SCS0009/Ping/CMakeLists.txt
+++ b/examples/SCS0009/Ping/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.5)
+set(project "Ping")
+project(${project})
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
+
+include_directories(../../../include)
+link_directories(../../../build)
+link_libraries(libSCServo.a)
+
+file(GLOB hdrs *h)
+file(GLOB srs *.cpp)
+
+add_executable(${project} ${hdrs} ${srs})

--- a/examples/SCS0009/Ping/CMakeLists.txt
+++ b/examples/SCS0009/Ping/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 set(project "Ping")
 project(${project})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+add_compile_options(-O3)
 
 include_directories(../../../include)
 link_directories(../../../build)

--- a/examples/SCS0009/Ping/CMakeLists.txt
+++ b/examples/SCS0009/Ping/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 set(project "Ping")
 project(${project})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
-
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+add_compile_options(-O3)
 include_directories(../../../include)
 link_directories(../../../build)
 link_libraries(libSCServo.a)

--- a/examples/SCS0009/Ping/Ping.cpp
+++ b/examples/SCS0009/Ping/Ping.cpp
@@ -9,7 +9,7 @@
  * - Troubleshooting communication issues
  *
  * **Hardware Requirements:**
- * - SCSCL series servo motor
+ * - SCS0009 series servo motor
  * - Serial port connection
  * - Servo ID must be known (default: ID=1)
  *

--- a/examples/SCS0009/Ping/Ping.cpp
+++ b/examples/SCS0009/Ping/Ping.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file Ping.cpp
+ * @brief Example: Ping servo to test connectivity
+ * 
+ * @details Demonstrates the PING command to check if a servo with a specific ID
+ * is connected and responsive on the serial bus. This is useful for:
+ * - Verifying servo connectivity before operation
+ * - Discovering servo IDs on the bus
+ * - Troubleshooting communication issues
+ *
+ * **Hardware Requirements:**
+ * - SCSCL series servo motor
+ * - Serial port connection
+ * - Servo ID must be known (default: ID=1)
+ *
+ * **Key Features Demonstrated:**
+ * - Serial port initialization
+ * - PING command usage
+ * - Error detection and reporting
+ *
+ * **Usage:**
+ * @code{.sh}
+ * ./Ping /dev/ttyUSB0
+ * @endcode
+ *
+ * **Expected Output:**
+ * - Success: "ID:1" (or whichever ID responded)
+ * - Failure: "Ping servo ID error!"
+ *
+ * @note Broadcast PING (ID=0xFE) only works when a single servo is on the bus
+ * @note This example tests servo ID=1
+ * @see SCS0009::Ping() for function details
+ */
+
+#include <iostream>
+#include "SCServo.h"
+#include "SCS0009.h"
+
+SCS0009 s9;  /// servo controller instance
+
+/**
+ * @brief Main function - tests servo connectivity with PING command
+ * @param argc Argument count (must be 2)
+ * @param argv Argument vector [program_name, serial_port]
+ * @return 1 on success, 0 on error
+ */
+int main(int argc, char **argv)
+{
+	if(argc<2){
+        std::cout<<"argc error!"<<std::endl;
+        return 0;
+	}
+	std::cout<<"serial:"<<argv[1]<<std::endl;
+    if(!s9.begin(1000000, argv[1])){
+        std::cout<<"Failed to init scs0009 motor!"<<std::endl;
+        return 0;
+    }
+	int ID = s9.Ping(1);
+	if(ID!=-1){
+		std::cout<<"ID:"<<ID<<std::endl;
+	}else{
+		std::cout<<"Ping servo ID error!"<<std::endl;
+	}
+	s9.end();
+	return 1;
+}

--- a/examples/SCS0009/Ping/Ping.cpp
+++ b/examples/SCS0009/Ping/Ping.cpp
@@ -55,12 +55,15 @@ int main(int argc, char **argv)
         std::cout<<"Failed to init scs0009 motor!"<<std::endl;
         return 0;
     }
-	int ID = s9.Ping(1);
-	if(ID!=-1){
-		std::cout<<"ID:"<<ID<<std::endl;
-	}else{
-		std::cout<<"Ping servo ID error!"<<std::endl;
-	}
-	s9.end();
-	return 1;
+    
+    int ID = s9.Ping(1);
+    if(ID!=-1){
+        std::cout<<"ID:"<<ID<<std::endl;
+        s9.end();
+        return 1;
+    }else{
+        std::cout<<"Ping servo ID error!"<<std::endl;
+        s9.end();
+        return 0;
+    }
 }

--- a/include/SCS0009.h
+++ b/include/SCS0009.h
@@ -29,12 +29,19 @@
 //-------EEPROM (Read/Write)--------
 #define SCS0009_ID 5
 #define SCS0009_BAUD_RATE 6
-#define SCS0009_RETURN_DELAY        7
-#define SCS0009_STATUS_RETURN_LEVEL 8
+
+// hang-time of how long the servo waits to respond to a host
+// Might need to be tuned if you start seeing a lot of unacked status packets or retransmits
+// at either end of the conversation
+// These registers are present on the SCS0009 but not on some other Feetech servos 
+#define SCS0009_RETURN_DELAY        7    // 0x07 — response delay in 2µs units
+#define SCS0009_STATUS_RETURN_LEVEL 8    // 0x08 — 0=ping only, 1=read, 2=all
+
 #define SCS0009_MIN_ANGLE_LIMIT_L 9
 #define SCS0009_MIN_ANGLE_LIMIT_H 10
 #define SCS0009_MAX_ANGLE_LIMIT_L 11
 #define SCS0009_MAX_ANGLE_LIMIT_H 12
+
 #define SCS0009_CW_DEAD 26
 #define SCS0009_CCW_DEAD 27
 
@@ -64,16 +71,12 @@
 
 // Direction bit positions
 
-#define SCS0009_LOAD_DIRECTION_BIT_POS 15
-#define SCS0009_PWM_DIRECTION_BIT_POS 10
+#define SCS0009_DIRECTION_BIT_POS 15
 
 // hang-time of how long the servo waits to respond to a host
 // Might need to be tuned if you start seeing a lot of unacked status packets or retransmits
 // at either end of the conversation
-/ These registers are present on the SCS0009 but not on some other Feetech servos 
 
-#define SCS0009_RETURN_DELAY        7    // 0x07 — response delay in 2µs units
-#define SCS0009_STATUS_RETURN_LEVEL 8    // 0x08 — 0=ping only, 1=read, 2=all
 /**
  * @class SCS0009
  * @brief Application layer interface for SCS0009 series serial servos

--- a/include/SCS0009.h
+++ b/include/SCS0009.h
@@ -1,0 +1,117 @@
+﻿/**
+ * @file SCS0009.h
+ * @brief Feetech SCS0009 Series Serial Servo Application Layer
+ *
+ * @details This file maps very closely to the SCSCL.h file modulo 
+ * - a few details 
+ */
+
+#ifndef _SCS0009_H
+#define _SCS0009_H
+#include "INST.h"
+#include "SCSerial.h"
+
+// Baud rate definitions
+#define	SCS0009_1M 0
+#define	SCS0009_0_5M 1
+#define	SCS0009_250K 2
+#define	SCS0009_128K 3
+#define	SCS0009_115200 4
+#define	SCS0009_76800	5
+#define	SCS0009_57600	6
+#define	SCS0009_38400	7
+
+// Memory table definitions
+//-------EEPROM (Read-only)--------
+#define SCS0009_VERSION_L 3
+#define SCS0009_VERSION_H 4
+
+//-------EEPROM (Read/Write)--------
+#define SCS0009_ID 5
+#define SCS0009_BAUD_RATE 6
+#define SCS0009_RETURN_DELAY        7
+#define SCS0009_STATUS_RETURN_LEVEL 8
+#define SCS0009_MIN_ANGLE_LIMIT_L 9
+#define SCS0009_MIN_ANGLE_LIMIT_H 10
+#define SCS0009_MAX_ANGLE_LIMIT_L 11
+#define SCS0009_MAX_ANGLE_LIMIT_H 12
+#define SCS0009_CW_DEAD 26
+#define SCS0009_CCW_DEAD 27
+
+//-------SRAM (Read/Write)--------
+#define SCS0009_TORQUE_ENABLE 40
+#define SCS0009_ACC 41
+#define SCS0009_GOAL_POSITION_L 42
+#define SCS0009_GOAL_POSITION_H 43
+#define SCS0009_GOAL_TIME_L 44
+#define SCS0009_GOAL_TIME_H 45
+#define SCS0009_GOAL_SPEED_L 46
+#define SCS0009_GOAL_SPEED_H 47
+#define SCS0009_LOCK 48
+
+//-------SRAM (Read-only)--------
+#define SCS0009_PRESENT_POSITION_L 56
+#define SCS0009_PRESENT_POSITION_H 57
+#define SCS0009_PRESENT_SPEED_L 58
+#define SCS0009_PRESENT_SPEED_H 59
+#define SCS0009_PRESENT_LOAD_L 60
+#define SCS0009_PRESENT_LOAD_H 61
+#define SCS0009_PRESENT_VOLTAGE 62
+#define SCS0009_PRESENT_TEMPERATURE 63
+#define SCS0009_MOVING 66
+#define SCS0009_PRESENT_CURRENT_L 69
+#define SCS0009_PRESENT_CURRENT_H 70
+
+// Direction bit positions
+
+#define SCS0009_LOAD_DIRECTION_BIT_POS 15
+#define SCS0009_PWM_DIRECTION_BIT_POS 10
+
+// hang-time of how long the servo waits to respond to a host
+// Might need to be tuned if you start seeing a lot of unacked status packets or retransmits
+// at either end of the conversation
+/ These registers are present on the SCS0009 but not on some other Feetech servos 
+
+#define SCS0009_RETURN_DELAY        7    // 0x07 — response delay in 2µs units
+#define SCS0009_STATUS_RETURN_LEVEL 8    // 0x08 — 0=ping only, 1=read, 2=all
+/**
+ * @class SCS0009
+ * @brief Application layer interface for SCS0009 series serial servos
+ *
+ * **Inheritance:**
+ * Inherits from SCSerial for serial communication and SCS protocol handling
+ *
+ * @see SCSCL and others for similar servo series interface
+ * @see SCSerial for communication layer
+ */
+class SCS0009 : public SCSerial
+{
+public:
+	SCS0009();
+	SCS0009(u8 End);
+	SCS0009(u8 End, u8 Level);
+
+
+	virtual int WritePos(u8 ID, u16 Position, u16 Time, u16 Speed = 0);
+	virtual int RegWritePos(u8 ID, u16 Position, u16 Time, u16 Speed = 0);
+	virtual void SyncWritePos(u8 ID[], u8 IDN, u16 Position[], u16 Time[], u16 Speed[]);
+	virtual int Mode(u8 ID, u8 mode); // Set operating mode (implementation via angle limits for SCS0009)
+	virtual int InitMotor(u8 ID, u8 mode, u8 enableTorque = 1); // Initialize motor with mode and torque (unlocks EEPROM, sets mode, locks EEPROM, enables/disables torque)
+	virtual int PWMMode(u8 ID);
+	virtual int WritePWM(u8 ID, s16 pwmOut);
+	virtual int EnableTorque(u8 ID, u8 Enable);
+	virtual int unLockEeprom(u8 ID);
+	virtual int LockEeprom(u8 ID);
+	virtual int FeedBack(u8 ID);
+	virtual int ReadPos(u8 ID);
+	virtual int ReadSpeed(u8 ID);
+	virtual int ReadLoad(u8 ID);
+	virtual int ReadVoltage(u8 ID);
+	virtual int ReadTemper(u8 ID);
+	virtual int ReadMove(u8 ID);
+	virtual int ReadCurrent(u8 ID);
+private:
+	u8 Mem[SCS0009_PRESENT_CURRENT_H-SCS0009_PRESENT_POSITION_L+1];
+};
+
+#endif

--- a/include/SCServo.h
+++ b/include/SCServo.h
@@ -22,7 +22,7 @@
  * @endcode
  *
  * @note This file only includes headers; link against libSCServo.a for implementations
- * @see SMS_STS.h, SCSCL.h, HLSCL.h for protocol documentation
+ * @see SMS_STS.h, SCSCL.h, SCS0009.h HLSCL.h for protocol documentation
  */
 
 #ifndef _SCSERVO_H
@@ -31,5 +31,6 @@
 #include "SCSCL.h"
 #include "SMS_STS.h"
 #include "HLSCL.h"
-/*additional support for SC0009 from Amazing Hand */
+#include "SCS0009.h"
+/* additional support for SCS0009 from Amazing Hand */
 #endif

--- a/include/SCServo.h
+++ b/include/SCServo.h
@@ -9,6 +9,7 @@
  * - SMS_STS: SMS and STS series (3 operating modes: servo, wheel closed-loop, wheel open-loop)
  * - SCSCL: SCSCL series (position control and PWM mode)
  * - HLSCL: HLS series (servo, wheel, and force control modes)
+ * - SCS0009: Servos used by the AmazingHand v1 servos 
  *
  * **Usage:**
  * @code
@@ -30,4 +31,5 @@
 #include "SCSCL.h"
 #include "SMS_STS.h"
 #include "HLSCL.h"
+/*additional support for SC0009 from Amazing Hand */
 #endif

--- a/src/SCS0009.cpp
+++ b/src/SCS0009.cpp
@@ -109,6 +109,7 @@ int SCS0009::InitMotor(u8 ID, u8 mode, u8 enableTorque)
 	// Set mode
 	ret = Mode(ID, mode);
 	if (ret == 0) {
+                LockEeprom(ID);
 		this->Err = 1;
 		return 0;
 	}
@@ -210,7 +211,9 @@ int SCS0009::ReadSpeed(u8 ID)
 		);
 	}
 	this->Err = 0;
-	return this->readSignedWord(ID, SCS0009_PRESENT_SPEED_L, SCS0009_DIRECTION_BIT_POS);
+        int speed = this->readSignedWord(ID, SCS0009_PRESENT_SPEED_L, SCS0009_DIRECTION_BIT_POS);
+	if (speed == -1) this->Err = 1;
+	return speed;`
 }
 
 /** @brief Read current load */
@@ -225,7 +228,11 @@ int SCS0009::ReadLoad(u8 ID)
 		);
 	}
 	this->Err = 0;
-	return this->readSignedWord(ID, SCS0009_PRESENT_LOAD_L, SCS0009_DIRECTION_BIT_POS);
+        int load = this->readSignedWord(ID, SCS0009_PRESENT_LOAD_L, 
+                                            SCS0009_DIRECTION_BIT_POS
+                         );
+	if (load == -1) this->Err = 1;
+	return load;
 }
 
 /** @brief Read supply voltage */
@@ -288,5 +295,9 @@ int SCS0009::ReadCurrent(u8 ID)
 		);
 	}
 	this->Err = 0;
-	return this->readSignedWord(ID, SCS0009_PRESENT_CURRENT_L, SCS0009_DIRECTION_BIT_POS);
+        current = this->readSignedWord(ID, SCS0009_PRESENT_CURRENT_L,
+                                           SCS0009_DIRECTION_BIT_POS
+                                      );
++	if (current == -1) this->Err = 1;
++	return current;
 }

--- a/src/SCS0009.cpp
+++ b/src/SCS0009.cpp
@@ -213,7 +213,7 @@ int SCS0009::ReadSpeed(u8 ID)
 	this->Err = 0;
         int speed = this->readSignedWord(ID, SCS0009_PRESENT_SPEED_L, SCS0009_DIRECTION_BIT_POS);
 	if (speed == -1) this->Err = 1;
-	return speed;`
+	return speed;
 }
 
 /** @brief Read current load */
@@ -295,9 +295,9 @@ int SCS0009::ReadCurrent(u8 ID)
 		);
 	}
 	this->Err = 0;
-        current = this->readSignedWord(ID, SCS0009_PRESENT_CURRENT_L,
+        int current = this->readSignedWord(ID, SCS0009_PRESENT_CURRENT_L,
                                            SCS0009_DIRECTION_BIT_POS
                                       );
-+	if (current == -1) this->Err = 1;
-+	return current;
+	if (current == -1) this->Err = 1;
+	return current;
 }

--- a/src/SCS0009.cpp
+++ b/src/SCS0009.cpp
@@ -1,0 +1,292 @@
+﻿/**
+ * @file SCS0009.cpp
+ * @brief Implementation of SCS0009 Series Serial Servo Application Layer
+ *
+ * @details This file implements the control functions for Feetech SCS0009 series
+ *  This code is quite similar to that used to control the SCSCL series. 
+ *  Most of the relevant changes can be found in SCS0009.h which has the values
+ *  and register memory locations used in the SCS0009 firmware vs. the SCSCL series. 
+ */ 
+
+#include "SCS0009.h"
+#include "INST.h"
+#include "SyncWriteBuffer.h"
+#include <cstring>
+#include <iostream>
+
+/**
+ * @brief Default constructor - initializes with little-endian byte order
+ */
+SCS0009::SCS0009() : SCSerial(1) {}
+
+/**
+ * @brief Constructor with endianness parameter
+ * @param End Endianness flag (0=little-endian, 1=big-endian)
+ */
+SCS0009::SCS0009(u8 End) : SCSerial(End) {}
+
+/**
+ * @brief Constructor with endianness and response level
+ * @param End Endianness flag (0=little-endian, 1=big-endian)
+ * @param Level Response level (0=ping only, 1=read only, 2=all commands)
+ */
+SCS0009::SCS0009(u8 End, u8 Level) : SCSerial(End, Level) {}
+
+int SCS0009::WritePos(u8 ID, u16 Position, u16 Time, u16 Speed)
+{
+	u8 bBuf[6];
+	this->Host2SCS(bBuf+0, bBuf+1, Position);
+	this->Host2SCS(bBuf+2, bBuf+3, Time);
+	this->Host2SCS(bBuf+4, bBuf+5, Speed);
+    
+	return this->genWrite(ID, SCS0009_GOAL_POSITION_L, bBuf, 6);
+}
+
+int SCS0009::RegWritePos(u8 ID, u16 Position, u16 Time, u16 Speed)
+{
+	u8 bBuf[6];
+	this->Host2SCS(bBuf+0, bBuf+1, Position);
+	this->Host2SCS(bBuf+2, bBuf+3, Time);
+	this->Host2SCS(bBuf+4, bBuf+5, Speed);
+    
+	return this->regWrite(ID, SCS0009_GOAL_POSITION_L, bBuf, 6);
+}
+
+void SCS0009::SyncWritePos(u8 ID[], u8 IDN, u16 Position[], u16 Time[], u16 Speed[])
+{
+	SyncWriteBuffer buffer(IDN, 6);
+	if(!buffer.isValid()){
+            this->Err = 1;
+		return;
+	}
+	for(u8 i = 0; i<IDN; i++){
+		u8 bBuf[6];
+		u16 T, V;
+		T = Time ? Time[i] : 0;
+		V = Speed ? Speed[i] : 0;
+		this->Host2SCS(bBuf+0, bBuf+1, Position[i]);
+		this->Host2SCS(bBuf+2, bBuf+3, T);
+		this->Host2SCS(bBuf+4, bBuf+5, V);
+		buffer.writeMotorData(i, bBuf, 6);
+	}
+	this->syncWrite(ID, IDN, SCS0009_GOAL_POSITION_L, buffer.getBuffer(), 6);
+}
+
+/** @brief Set operating mode (SCS0009 uses angle limits for mode control) */
+int SCS0009::Mode(u8 ID, u8 mode)
+{
+	// For SCS0009: mode 0 = position mode (set angle limits), mode 1 = PWM mode (clear angle limits)
+	if (mode == 0) {
+                u8 bBuf[4];
+                this->Host2SCS(bBuf+0,bBuf+1,0);
+                this->Host2SCS(bBuf+2,bBuf+3,1023);
+                return this->genWrite(ID, SCS0009_MIN_ANGLE_LIMIT_L,bBuf,4);
+        }
+        else if (mode == 1) { 
+               return PWMMode(ID);
+	} else { 
+                /* defensively refuse other values for mode-setting */
+		return 0; 
+	}
+}
+
+/**
+ * @brief Initialize motor with mode and torque settings
+ * @param ID Servo ID
+ * @param mode Operating mode
+ * @param enableTorque 1 to enable torque, 0 to disable
+ * @return 1 on success, 0 on failure
+ */
+int SCS0009::InitMotor(u8 ID, u8 mode, u8 enableTorque)
+{
+	// Unlock EEPROM
+	int ret = unLockEeprom(ID);
+	if (ret == 0) {
+		this->Err = 1;
+		return 0;
+	}
+
+	// Set mode
+	ret = Mode(ID, mode);
+	if (ret == 0) {
+		this->Err = 1;
+		return 0;
+	}
+
+	// Lock EEPROM
+	ret = LockEeprom(ID);
+	if (ret == 0) {
+		this->Err = 1;
+		return 0;
+	}
+
+	// Enable/disable torque
+	ret = EnableTorque(ID, enableTorque);
+	if (ret == 0) {
+		this->Err = 1;
+		return 0;
+	}
+
+	this->Err = 0;
+	return 1;
+}
+
+int SCS0009::PWMMode(u8 ID)
+{
+	u8 bBuf[4] = {0, 0, 0, 0};
+	return this->genWrite(ID, SCS0009_MIN_ANGLE_LIMIT_L, bBuf, 4);
+}
+
+int SCS0009::WritePWM(u8 ID, s16 pwmOut)
+{
+	u16 encodedPwm = ServoUtils::encodeSignedValue(pwmOut, SCS0009_DIRECTION_BIT_POS);
+
+	u8 bBuf[2];
+	this->Host2SCS(bBuf+0, bBuf+1, encodedPwm);
+	return this->genWrite(ID, SCS0009_GOAL_TIME_L, bBuf, 2);
+}
+
+/** @brief Enable/disable servo torque */
+int SCS0009::EnableTorque(u8 ID, u8 Enable)
+{
+	return this->writeByte(ID, SCS0009_TORQUE_ENABLE, Enable);
+}
+
+/** @brief Unlock EEPROM */
+int SCS0009::unLockEeprom(u8 ID)
+{
+	return this->writeByte(ID, SCS0009_LOCK, 0);
+}
+
+/** @brief Lock EEPROM */
+int SCS0009::LockEeprom(u8 ID)
+{
+	return this->writeByte(ID, SCS0009_LOCK, 1);
+}
+
+/**
+ * @brief Read all feedback data from servo
+ * @param ID Servo ID
+ * @return 1 on success, 0 on failure
+ */
+int SCS0009::FeedBack(u8 ID)
+{
+	int nLen = this->Read(ID, SCS0009_PRESENT_POSITION_L, Mem, sizeof(Mem));
+	if(nLen!=sizeof(Mem)){
+		this->Err = 1;
+		return 0;
+	}
+	this->Err = 0;
+	return 1;
+}
+	
+/** @brief Read current position from cache (FeedBack must be called first) or directly from servo */
+int SCS0009::ReadPos(u8 ID)
+{
+	int Pos = -1;
+	if(ID==(u8)-1){
+		Pos = Mem[SCS0009_PRESENT_POSITION_H-SCS0009_PRESENT_POSITION_L];
+		Pos <<= 8;
+		Pos |= Mem[SCS0009_PRESENT_POSITION_L-SCS0009_PRESENT_POSITION_L];
+	}else{
+		this->Err = 0;
+		Pos = this->readWord(ID, SCS0009_PRESENT_POSITION_L);
+		if(Pos==-1){
+			this->Err = 1;
+		}
+	}
+	return Pos;
+}
+
+/** @brief Read current speed */
+int SCS0009::ReadSpeed(u8 ID)
+{
+	if(ID == (u8)-1) {
+		return ServoUtils::readSignedWordFromBuffer(
+			Mem,
+			SCS0009_PRESENT_SPEED_L - SCS0009_PRESENT_POSITION_L,
+			SCS0009_PRESENT_SPEED_H - SCS0009_PRESENT_POSITION_L,
+			SCS0009_DIRECTION_BIT_POS
+		);
+	}
+	this->Err = 0;
+	return this->readSignedWord(ID, SCS0009_PRESENT_SPEED_L, SCS0009_DIRECTION_BIT_POS);
+}
+
+/** @brief Read current load */
+int SCS0009::ReadLoad(u8 ID)
+{
+	if(ID == (u8)-1) {
+		return ServoUtils::readSignedWordFromBuffer(
+			Mem,
+			SCS0009_PRESENT_LOAD_L - SCS0009_PRESENT_POSITION_L,
+			SCS0009_PRESENT_LOAD_H - SCS0009_PRESENT_POSITION_L,
+			SCS0009_DIRECTION_BIT_POS
+		);
+	}
+	this->Err = 0;
+	return this->readSignedWord(ID, SCS0009_PRESENT_LOAD_L, SCS0009_DIRECTION_BIT_POS);
+}
+
+/** @brief Read supply voltage */
+int SCS0009::ReadVoltage(u8 ID)
+{
+	int Voltage = -1;
+	if(ID==(u8)-1){
+		Voltage = Mem[SCS0009_PRESENT_VOLTAGE-SCS0009_PRESENT_POSITION_L];
+	}else{
+		this->Err = 0;
+		Voltage = this->readByte(ID, SCS0009_PRESENT_VOLTAGE);
+		if(Voltage==-1){
+			this->Err = 1;
+		}
+	}
+	return Voltage;
+}
+
+/** @brief Read internal temperature */
+int SCS0009::ReadTemper(u8 ID)
+{
+	int Temper = -1;
+	if(ID==(u8)-1){
+		Temper = Mem[SCS0009_PRESENT_TEMPERATURE-SCS0009_PRESENT_POSITION_L];
+	}else{
+		this->Err = 0;
+		Temper = this->readByte(ID, SCS0009_PRESENT_TEMPERATURE);
+		if(Temper==-1){
+			this->Err = 1;
+		}
+	}
+	return Temper;
+}
+
+/** @brief Read movement status */
+int SCS0009::ReadMove(u8 ID)
+{
+	int Move = -1;
+	if(ID==(u8)-1){
+		Move = Mem[SCS0009_MOVING-SCS0009_PRESENT_POSITION_L];
+	}else{
+		this->Err = 0;
+		Move = this->readByte(ID, SCS0009_MOVING);
+		if(Move==-1){
+			this->Err = 1;
+		}
+	}
+	return Move;
+}
+
+/** @brief Read motor current */
+int SCS0009::ReadCurrent(u8 ID)
+{
+	if(ID == (u8)-1) {
+		return ServoUtils::readSignedWordFromBuffer(
+			Mem,
+			SCS0009_PRESENT_CURRENT_L - SCS0009_PRESENT_POSITION_L,
+			SCS0009_PRESENT_CURRENT_H - SCS0009_PRESENT_POSITION_L,
+			SCS0009_DIRECTION_BIT_POS
+		);
+	}
+	this->Err = 0;
+	return this->readSignedWord(ID, SCS0009_PRESENT_CURRENT_L, SCS0009_DIRECTION_BIT_POS);
+}


### PR DESCRIPTION
re-opening after initial round of coderabbit linting which pointed out broken Markdown, possible silent failure modes in SCS0009.cpp and the SCS0009 Ping.cpp example. 
When accepted this will add in support for the SCS0009 servo from Feetech, which is used in the Pollen Robotic AmazingHand. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SCS0009 servo support: position control, PWM mode, torque control, EEPROM lock/unlock, and telemetry (position, speed, load, voltage, temperature, movement, current)

* **Examples**
  * New Ping example to test SCS0009 connectivity and a buildable example project

* **Documentation**
  * README updated with SCS0009 support, model notes, and tested-platform info
<!-- end of auto-generated comment: release notes by coderabbit.ai -->