### PR TITLE
Clean cmake and add installation targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,81 @@
-cmake_minimum_required(VERSION 3.10)
-set(project "SCServo")
-project(${project} LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.14)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
+project(SCServo
+  VERSION 1.0.0
+  LANGUAGES CXX
+  DESCRIPTION "Feetech serial bus servo SDK for Linux")
 
-# Include SMS_STS, SCSCL, HLSCL, and base classes
-set(hdrs include/SMS_STS.h include/SCSerial.h include/SCS.h include/SCSCL.h 
-         include/SCS0009.h
-         include/INST.h include/HLSCL.h include/ServoUtils.h
-         include/SyncWriteBuffer.h include/ServoErrors.h include/SCServo.h)
-set(srs src/SMS_STS.cpp src/SCSerial.cpp src/SCS.cpp src/SCSCL.cpp src/SCS0009.cpp
-        src/HLSCL.cpp)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
-add_library(${project} STATIC ${hdrs} ${srs})
-target_include_directories(${project} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include/${PROJECT_NAME}/scservo>
+set(SCSERVO_HEADERS
+  include/INST.h
+  include/SCS.h
+  include/SCS0009.h
+  include/SCSCL.h
+  include/SCSerial.h
+  include/SCServo.h
+  include/SMS_STS.h
+  include/HLSCL.h
+  include/ServoErrors.h
+  include/ServoUtils.h
+  include/SyncWriteBuffer.h
 )
-set_target_properties(${project} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+set(SCSERVO_SOURCES
+  src/SMS_STS.cpp
+  src/SCSerial.cpp
+  src/SCS.cpp
+  src/SCS0009.cpp
+  src/SCSCL.cpp
+  src/HLSCL.cpp
+)
+
+add_library(SCServo STATIC ${SCSERVO_SOURCES} ${SCSERVO_HEADERS})
+
+target_include_directories(SCServo PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/scservo>
+)
+
+target_compile_features(SCServo PUBLIC cxx_std_17)
+
+set_target_properties(SCServo PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+)
+
+install(TARGETS SCServo
+  EXPORT SCServoTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/scservo
+  FILES_MATCHING PATTERN "*.h"
+)
+
+install(EXPORT SCServoTargets
+  FILE SCServoTargets.cmake
+  NAMESPACE SCServo::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SCServo
+)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SCServoConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/SCServoConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SCServo
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/SCServoConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMinorVersion
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/SCServoConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/SCServoConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SCServo
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ target_include_directories(SCServo PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/scservo>
 )
 
-target_compile_features(SCServo PUBLIC cxx_std_17)
+target_compile_features(SCServo PRIVATE cxx_std_17)
 
 set_target_properties(SCServo PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/cmake/SCServoConfig.cmake.in
+++ b/cmake/SCServoConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/SCServoTargets.cmake")
+check_required_components(SCServo)


### PR DESCRIPTION
I'm looking at using this library in a pixi/robostack/conda project and the first step of that is to add some install targets to the cmake file which should be generally useful.

The main things are:
- Adds VERSION/DESCRIPTION to project()
- Replaces CMAKE_CXX_FLAGS string with target_compile_features
- Adds install rules for the library, headers, and a CMake package config
  so downstream projects can use find_package(SCServo)
- Adds cmake/SCServoConfig.cmake.in to support SCServo:: imported targets

I have a second PR ready which changes the include directory but that is more invasive and will affect consumers https://github.com/MJohnson459/SCServo_Linux/pull/2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized CMake build configuration for improved compatibility and standards compliance
  * Enhanced package installation and export support for better integration with CMake workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adityakamath/SCServo_Linux/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->